### PR TITLE
Fix for engines that do not support generators

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -22,6 +22,8 @@
 	    alert("Returned from modal: " + ret);
 	  });
 	});
+      </script>
+      <script>
 	document.getElementById('button2').addEventListener('click', function() {
 	  var ret = window.showModalDialog("demo-modal.html", "some argument", "dialogWidth:500px;dialogHeight:200px");
 	  alert("Returned from modal: " + ret);


### PR DESCRIPTION
Because yield and function\* are used in a script, script engines that do not support generators fails hard due to syntax errors. Separating the scripts make the engine parse each of the scrips individually and syntax errors in a certain script do not break the rest of the scripts.
